### PR TITLE
Standardize license headers in Python files

### DIFF
--- a/detect.py
+++ b/detect.py
@@ -1,3 +1,5 @@
+# Ultralytics 🚀 AGPL-3.0 License - https://ultralytics.com/license
+
 import argparse
 import time
 from sys import platform

--- a/models.py
+++ b/models.py
@@ -1,7 +1,8 @@
+# Ultralytics 🚀 AGPL-3.0 License - https://ultralytics.com/license
+
 from collections import defaultdict
 
 import torch.nn as nn
-
 from utils.utils import *
 
 

--- a/utils/datasets.py
+++ b/utils/datasets.py
@@ -1,3 +1,5 @@
+# Ultralytics 🚀 AGPL-3.0 License - https://ultralytics.com/license
+
 import glob
 import math
 import os

--- a/utils/utils.py
+++ b/utils/utils.py
@@ -1,3 +1,5 @@
+# Ultralytics 🚀 AGPL-3.0 License - https://ultralytics.com/license
+
 import random
 
 import cv2


### PR DESCRIPTION
This PR updates all Python file headers to use a standardized license format. 🔄

### Changes:

- 📝 Standardized header: `# Ultralytics 🚀 AGPL-3.0 License - https://ultralytics.com/license`
- 🧹 Ensures consistent spacing after headers
- 🔍 Applies to all Python files except those in `venv`

Learn more about [Ultralytics licensing](https://ultralytics.com/license) 📚